### PR TITLE
Apply hint color after default color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Fixes
 
+- \#8 inconsistent coloring of the default hint for `confirm`
+
 ## v2.1.5
 
 #### Fixes

--- a/survey/__init__.py
+++ b/survey/__init__.py
@@ -174,9 +174,10 @@ def confirm(*args,
     """
 
     if not 'hint' in kwargs:
-        template = helpers.paint('({0}/{1}) ', _colors.hint)
+        template = '({0}/{1}) '
         color = kwargs.get('color', _default_color)
-        kwargs['hint'] = utils.hint.confirm(template, default, color = color)
+        hint = utils.hint.confirm(template, default, color = color)
+        kwargs['hint'] = helpers.paint(hint, _colors.hint)
 
     helpers.exclude_arg(kwargs, 'limit')
 


### PR DESCRIPTION
<!--- Thank you for contributing! --->

This fixes #7 by applying the color for the default answer first and coloring the entire hint second.