### PR TITLE
Fix _resolve and improve inquire_reply

### DIFF
--- a/survey/_routines.py
+++ b/survey/_routines.py
@@ -206,7 +206,8 @@ def _inquire_reply(widget,
                    result, 
                    color = _colors.basic('cyan')):
 
-    result = 'Yes' if result else 'No'
+    if isinstance(result, bool):
+        result = 'Yes' if result else 'No'
 
     result = _helpers.paint_text(color, result)
 

--- a/survey/_widgets.py
+++ b/survey/_widgets.py
@@ -125,7 +125,8 @@ class Widget:
 
         if value is self._product_mark:
             value = self._produce()
-            value = self._prepare(value)
+
+        value = self._prepare(value)
 
         return value
     

--- a/survey/_widgets.py
+++ b/survey/_widgets.py
@@ -847,7 +847,8 @@ class Inquire(AutoSubmit):
 
         value = super()._prepare(value)
 
-        value = self._options[value]
+        if value in self._options:
+            value = self._options[value]
 
         return value
     


### PR DESCRIPTION
Inquire was returning the key instead of the value it pointed to in the options map. This was confusing until I realized its `_prepare` function was never called, which is where it supposed to be converting the result value.

I also improved the `_inquire_reply`, which was expecting the result to always be a boolean. So no matter what you entered as an option, if the value was not explicitly False it always printed out "Yes". Instead it checks that the value is a bool, and then prints 'Yes'/'No' accordingly, otherwise it prints out what ever the result itself is.