### PR TITLE
fix: typing compatibility for lower python versions

### DIFF
--- a/survey/_widgets.py
+++ b/survey/_widgets.py
@@ -776,7 +776,7 @@ class AutoSubmitBase(Input):
         )
             
 
-_type_AutoSubmit_init_options  = list[str]
+_type_AutoSubmit_init_options  = typing.List[str]
 _type_AutoSubmit_init_tranform = _type_AutoSubmitBase_init_transform
     
 


### PR DESCRIPTION
Hello

```
  File "/Users/romeophillips/PycharmProjects/project/.venv/lib/python3.8/site-packages/survey/__init__.py", line 14, in <module>
    from . import _widgets as widgets
  File "/Users/romeophillips/PycharmProjects/project/.venv/lib/python3.8/site-packages/survey/_widgets.py", line 779, in <module>
    _type_AutoSubmit_init_options  = list[str]
TypeError: 'type' object is not subscriptable
```